### PR TITLE
Switch to openvox-strings

### DIFF
--- a/onceover-codequality.gemspec
+++ b/onceover-codequality.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.13"
 
   spec.add_runtime_dependency 'onceover', '~> 5.0'
+  spec.add_runtime_dependency 'openvox-strings', '>= 5.0', '< 7.0'
   spec.add_runtime_dependency 'puppet-lint', '~> 4.3'
-  spec.add_runtime_dependency 'puppet-strings', '~> 5.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 6.0'
 end


### PR DESCRIPTION
Without this, we pull openvox (through onceover) and puppet (through puppet-strings).